### PR TITLE
Fix mysql in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,14 @@ version: '2'
 services:
   mysql:
     restart: always
-    image: mysql:5.7
+    image: mysql/mysql-server:5.7
     ports:
       - "3306:3306"
     environment:
-      - MYSQL_ROOT_PASSWORD=root
-      - MYSQL_DATABASE=myapp
-      - MYSQL_USER=myapp
-      - MYSQL_PASSWORD
+      MYSQL_ROOT_PASSWORD: "root"
+      MYSQL_USER: "myapp"
+      MYSQL_PASSWORD: "myapp"
+      MYSQL_DATABASE: "myapp"
   postgres:
     restart: always
     image: postgres:9.5


### PR DESCRIPTION
Create a clean environment with

```
docker-compose rm
```

Then create fresh containers and start them

```
docker-compose up
```

Then you should be able to connect your database:

```
user@host ~/Repos/docker-php7-mysql-postgres (git)-[hotfix/compose] % docker exec -it dockerphp7mysqlpostgres_mysql_1 mysql --user=myapp --password=myapp --host=localhost myapp
mysql: [Warning] Using a password on the command line interface can be insecure.
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 2
Server version: 5.7.14 MySQL Community Server (GPL)

Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql>

```
